### PR TITLE
fix: fix window frozen when start dev mode for another project

### DIFF
--- a/src/223/main/java/dev/nocalhost/plugin/intellij/ui/action/workload/OpenProjectExecutor.java
+++ b/src/223/main/java/dev/nocalhost/plugin/intellij/ui/action/workload/OpenProjectExecutor.java
@@ -2,6 +2,7 @@ package dev.nocalhost.plugin.intellij.ui.action.workload;
 
 import com.intellij.ide.RecentProjectsManagerBase;
 import com.intellij.ide.impl.OpenProjectTask;
+import com.intellij.openapi.application.ApplicationManager;
 
 import java.nio.file.Paths;
 
@@ -9,6 +10,8 @@ public class OpenProjectExecutor {
 
     public static void open(String projectPath) {
         var task = OpenProjectTask.build();
-        RecentProjectsManagerBase.getInstanceEx().openProjectSync(Paths.get(projectPath), task.withRunConfigurators());
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            RecentProjectsManagerBase.getInstanceEx().openProjectSync(Paths.get(projectPath), task.withRunConfigurators());
+        });
     }
 }


### PR DESCRIPTION
It looks like openProjectSync block the main thread, so wrap it by with thread pool

Signed-off-by: tianyu <tianyu@coding.net>