### PR TITLE
hotfix(gateway): fix cpu 100% in jetbrains gateway remote

### DIFF
--- a/src/main/java/dev/nocalhost/plugin/intellij/ui/SyncStatusWidget.java
+++ b/src/main/java/dev/nocalhost/plugin/intellij/ui/SyncStatusWidget.java
@@ -14,6 +14,7 @@ public class SyncStatusWidget implements StatusBarWidget {
 
     private final StatusBar statusBar;
     private final Project project;
+    private final SyncStatusPresentation syncStatusPresentation;
     private Thread updateThread = null;
     private boolean forceExit = false;
 
@@ -21,6 +22,7 @@ public class SyncStatusWidget implements StatusBarWidget {
     public SyncStatusWidget(Project project) {
         this.statusBar = WindowManager.getInstance().getStatusBar(project);
         this.project = project;
+        syncStatusPresentation = new SyncStatusPresentation(project, statusBar, this);
     }
 
     @Override
@@ -31,7 +33,7 @@ public class SyncStatusWidget implements StatusBarWidget {
 
     @Override
     public @Nullable WidgetPresentation getPresentation() {
-        return new SyncStatusPresentation(project, statusBar, this);
+        return syncStatusPresentation;
     }
 
     @Override


### PR DESCRIPTION
> In the remote environment of gateway, the getPresentation of SyncStatusWidget will be called frequently, causing the cpu to be full. For more information, please see the figure below.
> 
> ```
> root     1219752 1082398  6 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1219754 1082398  5 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1219766 1082398  7 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1219786 1082398  6 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1219809 1082398  6 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1219853 1082398  9 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1219867 1082398  9 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1219923 1082398 10 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1219949 1082398  7 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1219956 1082398  6 09:53 ?        00:00:00 /root/.nh/bin/nhctl check cluster --kubeconfig /root/.nh/intellij-plugin/kubeConfigs/842ad4cc6e4bbff97aece31fd84f
> root     1219964 1082398 10 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1219974 1082398  9 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1219992 1082398 11 09:53 ?        00:00:00 [nhctl] <defunct>
> root     1220027 1082398  7 09:53 ?        00:00:00 /root/.nh/bin/nhctl sync-status default.application --deployment xxx0704 --controller-type deployment --kubeconf
> root     1220042 1082398 10 09:53 ?        00:00:00 [nhctl] <defunct>
> root     1220068 1082398  7 09:53 ?        00:00:00 /root/.nh/bin/nhctl sync-status default.application --deployment xxx0704 --controller-type deployment --kubeconf
> root     1220075 1082398  9 09:53 ?        00:00:00 /root/.nh/bin/nhctl sync-status default.application --deployment xxx0704 --controller-type deployment --kubeconf
> root     1220108 1082398  8 09:53 ?        00:00:00 /root/.nh/bin/nhctl sync-status default.application --deployment xxx0704 --controller-type deployment --kubeconf
> root     1220109 1082398  8 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220111 1082398 10 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220119 1082398  9 09:53 ?        00:00:00 [nhctl] <defunct>
> root     1220144 1082398  8 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220154 1082398  7 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220156 1082398 10 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220158 1082398  8 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220164 1082398  8 09:53 ?        00:00:00 [nhctl] <defunct>
> root     1220189 1082398  7 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220207 1082398  8 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220208 1082398  8 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220213 1082398  7 09:53 ?        00:00:00 /root/.nh/bin/nhctl sync-status default.application --deployment xxx0704 --controller-type deployment --kubeconf
> root     1220226 1082398  7 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220234 1082398  8 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220239 1082398  7 09:53 ?        00:00:00 /root/.nh/bin/nhctl sync-status default.application --deployment xxx0704 --controller-type deployment --kubeconf
> root     1220241 1082398  7 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220242 1082398 10 09:53 ?        00:00:00 [nhctl]
> root     1220249 1082398  6 09:53 ?        00:00:00 /root/.nh/bin/nhctl sync-status default.application --deployment xxx0704 --controller-type deployment --kubeconf
> root     1220250 1082398  6 09:53 ?        00:00:00 /root/.nh/bin/nhctl sync-status default.application --deployment xxx0704 --controller-type deployment --kubeconf
> root     1220252 1082398  8 09:53 ?        00:00:00 [nhctl] <defunct>
> root     1220253 1082398  6 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220260 1082398  6 09:53 ?        00:00:00 /root/.nh/bin/nhctl sync-status default.application --deployment xxx0704 --controller-type deployment --kubeconf
> root     1220269 1082398  6 09:53 ?        00:00:00 /root/.nh/bin/nhctl dev associate-queryer --local-sync /data/xxx/PRC --json
> root     1220299 1082398  5 09:53 ?        00:00:00 /root/.nh/bin/nhctl sync-status default.application --deployment xxx0704 --controller-type deployment --kubeconf
> root     1220302 1082398  7 09:53 ?        00:00:00 [nhctl]
> root     1220320 1082398  6 09:53 ?        00:00:00 /root/.nh/bin/nhctl sync-status default.application --deployment xxx0704 --controller-type deployment --kubeconf
> ```
> 
> The detailed log is as follows
> 
> ```
> 2023-07-20 23:59:34,516 [   3562]   INFO - STDOUT - java.lang.Exception: get stack
> 2023-07-20 23:59:34,516 [   3562]   INFO - STDOUT -     at dev.nocalhost.plugin.intellij.ui.SyncStatusWidget.getPresentation(SyncStatusWidget.java:38)
> 2023-07-20 23:59:34,516 [   3562]   INFO - STDOUT -     at com.intellij.openapi.wm.impl.status.IdeStatusBarImplKt.createComponentByWidgetPresentation(IdeStatusBarImpl.kt:760)
> 2023-07-20 23:59:34,516 [   3562]   INFO - STDOUT -     at com.intellij.openapi.wm.impl.status.IdeStatusBarImplKt.wrap(IdeStatusBarImpl.kt:782)
> 2023-07-20 23:59:34,516 [   3562]   INFO - STDOUT -     at com.intellij.openapi.wm.impl.status.IdeStatusBarImplKt.access$wrap(IdeStatusBarImpl.kt:1)
> 2023-07-20 23:59:34,516 [   3562]   INFO - STDOUT -     at com.intellij.openapi.wm.impl.status.IdeStatusBarImpl$doInit$items$1$1$component$1.invokeSuspend(IdeStatusBarImpl.kt:284)
> 2023-07-20 23:59:34,516 [   3562]   INFO - STDOUT -     at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
> 2023-07-20 23:59:34,516 [   3562]   INFO - STDOUT -     at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
> 
> 
> 
> 2023-07-20 23:59:39,004 [   8050]   INFO - STDOUT - java.lang.Exception: get stack
> 2023-07-20 23:59:39,004 [   8050]   INFO - STDOUT -     at dev.nocalhost.plugin.intellij.ui.SyncStatusWidget.getPresentation(SyncStatusWidget.java:38)
> 2023-07-20 23:59:39,004 [   8050]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost.toProtocol(BackendStatusBarHost.kt:88)
> 2023-07-20 23:59:39,004 [   8050]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost.access$toProtocol(BackendStatusBarHost.kt:20)
> 2023-07-20 23:59:39,004 [   8050]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost$1$listener$1.widgetAdded(BackendStatusBarHost.kt:40)
> 2023-07-20 23:59:39,004 [   8050]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost$1.invokeSuspend(BackendStatusBarHost.kt:55)
> 2023-07-20 23:59:39,004 [   8050]   INFO - STDOUT -     at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
> 2023-07-20 23:59:39,004 [   8050]   INFO - STDOUT -     at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
> 2023-07-20 23:59:39,004 [   8050]   INFO - STDOUT -     at com.intellij.openapi.application.impl.DispatchedRunnable.run(DispatchedRunnable.kt:35)
> 2023-07-20 23:59:39,004 [   8050]   INFO - STDOUT -     at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:209)
> 
> 
> 2023-07-20 23:59:40,407 [   9453]   INFO - STDOUT - java.lang.Exception: get stack
> 2023-07-20 23:59:40,407 [   9453]   INFO - STDOUT -     at dev.nocalhost.plugin.intellij.ui.SyncStatusWidget.getPresentation(SyncStatusWidget.java:38)
> 2023-07-20 23:59:40,407 [   9453]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost.updateWidget(BackendStatusBarHost.kt:79)
> 2023-07-20 23:59:40,407 [   9453]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost.access$updateWidget(BackendStatusBarHost.kt:20)
> 2023-07-20 23:59:40,407 [   9453]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost$1$listener$1.widgetUpdated(BackendStatusBarHost.kt:47)
> 2023-07-20 23:59:40,407 [   9453]   INFO - STDOUT -     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> 2023-07-20 23:59:40,407 [   9453]   INFO - STDOUT -     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
> 2023-07-20 23:59:40,407 [   9453]   INFO - STDOUT -     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> 
> 
> 2023-07-20 23:59:40,580 [   9626]   INFO - STDOUT - java.lang.Exception: get stack
> 2023-07-20 23:59:40,580 [   9626]   INFO - STDOUT -     at dev.nocalhost.plugin.intellij.ui.SyncStatusWidget.getPresentation(SyncStatusWidget.java:38)
> 2023-07-20 23:59:40,580 [   9626]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost.updateWidget(BackendStatusBarHost.kt:79)
> 2023-07-20 23:59:40,580 [   9626]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost.access$updateWidget(BackendStatusBarHost.kt:20)
> 2023-07-20 23:59:40,580 [   9626]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost$1$listener$1.widgetUpdated(BackendStatusBarHost.kt:47)
> 2023-07-20 23:59:40,580 [   9626]   INFO - STDOUT -     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> 2023-07-20 23:59:40,580 [   9626]   INFO - STDOUT -     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
> 2023-07-20 23:59:40,580 [   9626]   INFO - STDOUT -     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> 
> 
> 
> 2023-07-20 23:59:41,545 [  10591]   INFO - STDOUT - java.lang.Exception: get stack
> 2023-07-20 23:59:41,545 [  10591]   INFO - STDOUT -     at dev.nocalhost.plugin.intellij.ui.SyncStatusWidget.getPresentation(SyncStatusWidget.java:38)
> 2023-07-20 23:59:41,545 [  10591]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost.updateWidget(BackendStatusBarHost.kt:79)
> 2023-07-20 23:59:41,545 [  10591]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost.access$updateWidget(BackendStatusBarHost.kt:20)
> 2023-07-20 23:59:41,545 [  10591]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost$1$listener$1.widgetUpdated(BackendStatusBarHost.kt:47)
> 2023-07-20 23:59:41,545 [  10591]   INFO - STDOUT -     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> 2023-07-20 23:59:41,545 [  10591]   INFO - STDOUT -     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
> 2023-07-20 23:59:41,545 [  10591]   INFO - STDOUT -     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> 2023-07-20 23:59:41,545 [  10591]   INFO - STDOUT -     at java.base/java.lang.reflect.Method.invoke(Method.java:568)
> 2023-07-20 23:59:41,545 [  10591]   INFO - STDOUT -     at com.intellij.util.EventDispatcher.dispatchVoidMethod(EventDispatcher.java:120)
> 2023-07-20 23:59:41,545 [  10591]   INFO - STDOUT -     at com.intellij.util.EventDispatcher.lambda$createMulticaster$1(EventDispatcher.java:85)
> 
> 
> 2023-07-20 23:59:42,533 [  11579]   INFO - STDOUT - java.lang.Exception: get stack
> 2023-07-20 23:59:42,533 [  11579]   INFO - STDOUT -     at dev.nocalhost.plugin.intellij.ui.SyncStatusWidget.getPresentation(SyncStatusWidget.java:38)
> 2023-07-20 23:59:42,533 [  11579]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost.updateWidget(BackendStatusBarHost.kt:79)
> 2023-07-20 23:59:42,533 [  11579]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost.access$updateWidget(BackendStatusBarHost.kt:20)
> 2023-07-20 23:59:42,533 [  11579]   INFO - STDOUT -     at com.jetbrains.rdserver.status.BackendStatusBarHost$1$listener$1.widgetUpdated(BackendStatusBarHost.kt:47)
> 2023-07-20 23:59:42,533 [  11579]   INFO - STDOUT -     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> 2023-07-20 23:59:42,533 [  11579]   INFO - STDOUT -     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
> 2023-07-20 23:59:42,533 [  11579]   INFO - STDOUT -     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> ```
> 
> Through analysis, the problem of modification can be solved by changing SyncStatusPresentation in SyncStatusWidget into member variables.
> 
> ```java
>     public SyncStatusWidget(Project project) {
>         this.statusBar = WindowManager.getInstance().getStatusBar(project);
>         this.project = project;
>         syncStatusPresentation = new SyncStatusPresentation(project, statusBar, this);
>     }
> 
>     @Override
>     public @Nullable WidgetPresentation getPresentation() {
>         return syncStatusPresentation;
>     }
> ```

