### PR TITLE
fix: rename back to Nocalhost

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ platformVersion=252
 
 kotlin.code.style=official
 kotlin.stdlib.default.dependency = false
-version=0.6.33
+version=0.6.34

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,5 +1,5 @@
 <idea-plugin>
-    <name>Nocalhost for Kubernetes</name>
+    <name>Nocalhost</name>
     <vendor url="https://nocalhost.dev/">Nocalhost</vendor>
 
     <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html


### PR DESCRIPTION
插件市场已经解锁了这个名字